### PR TITLE
Eigen::Ref use on problems 71 and 71b

### DIFF
--- a/schittkowski/problem_71.cc
+++ b/schittkowski/problem_71.cc
@@ -56,7 +56,7 @@ namespace roboptim
 	  const throw ();
 
 	void
-	impl_hessian (hessian_t& h, const_argument_ref& x, size_type)
+	impl_hessian (hessian_ref h, const_argument_ref& x, size_type)
 	  const throw ();
       };
 
@@ -83,7 +83,7 @@ namespace roboptim
 	  const throw ();
 
 	void
-	impl_hessian (hessian_t& h, const_argument_ref& x, size_type)
+	impl_hessian (hessian_ref h, const_argument_ref& x, size_type)
 	  const throw ();
       };
 
@@ -111,7 +111,7 @@ namespace roboptim
 	  const throw ();
 
 	void
-	impl_hessian (hessian_t& h, const_argument_ref&, size_type)
+	impl_hessian (hessian_ref h, const_argument_ref&, size_type)
 	  const throw ();
       };
 
@@ -195,7 +195,7 @@ namespace roboptim
       template <>
       void
       F<EigenMatrixSparse>::impl_hessian
-      (hessian_t& h, const_argument_ref& x, size_type) const throw ()
+      (hessian_ref h, const_argument_ref& x, size_type) const throw ()
       {
 	h.setZero ();
 	h.insert (0, 0) = 2 * x[3];
@@ -216,7 +216,7 @@ namespace roboptim
 
       template <typename T>
       void
-      F<T>::impl_hessian (hessian_t& h, const_argument_ref& x, size_type)
+      F<T>::impl_hessian (hessian_ref h, const_argument_ref& x, size_type)
 	const throw ()
       {
 	h.setZero ();
@@ -244,7 +244,7 @@ namespace roboptim
       template <>
       void
       G0<EigenMatrixSparse>::impl_hessian
-      (hessian_t& h, const_argument_ref& x, size_type) const throw ()
+      (hessian_ref h, const_argument_ref& x, size_type) const throw ()
       {
 	h.setZero ();
 	h.insert (0, 1) = x[2] * x[3];
@@ -267,7 +267,7 @@ namespace roboptim
 
       template <typename T>
       void
-      G0<T>::impl_hessian (hessian_t& h, const_argument_ref& x, size_type)
+      G0<T>::impl_hessian (hessian_ref h, const_argument_ref& x, size_type)
 	const throw ()
       {
 	h.setZero ();
@@ -296,7 +296,7 @@ namespace roboptim
       template <>
       void
       G1<EigenMatrixSparse>::impl_hessian
-      (hessian_t& h, const_argument_ref&, size_type) const throw ()
+      (hessian_ref h, const_argument_ref&, size_type) const throw ()
       {
 	h.setZero ();
 	h.insert (0, 0) = 2.;
@@ -307,7 +307,7 @@ namespace roboptim
 
       template <typename T>
       void
-      G1<T>::impl_hessian (hessian_t& h, const_argument_ref&, size_type)
+      G1<T>::impl_hessian (hessian_ref h, const_argument_ref&, size_type)
 	const throw ()
       {
 	h.setZero ();

--- a/schittkowski/problem_71b.cc
+++ b/schittkowski/problem_71b.cc
@@ -56,7 +56,7 @@ namespace roboptim
 	  const throw ();
 
 	void
-	impl_hessian (hessian_t& h, const_argument_ref& x, size_type)
+	impl_hessian (hessian_ref h, const_argument_ref& x, size_type)
 	  const throw ();
       };
 
@@ -85,7 +85,7 @@ namespace roboptim
 	  const throw ();
 
 	void
-	impl_hessian (hessian_t& h, const_argument_ref& x, size_type)
+	impl_hessian (hessian_ref h, const_argument_ref& x, size_type)
 	  const throw ();
       };
 
@@ -165,7 +165,7 @@ namespace roboptim
       template <>
       void
       F<EigenMatrixSparse>::impl_hessian
-      (hessian_t& h, const_argument_ref& x, size_type) const throw ()
+      (hessian_ref h, const_argument_ref& x, size_type) const throw ()
       {
 	h.setZero ();
 	h.insert (0, 0) = 2 * x[3];
@@ -186,7 +186,7 @@ namespace roboptim
 
       template <typename T>
       void
-      F<T>::impl_hessian (hessian_t& h, const_argument_ref& x, size_type)
+      F<T>::impl_hessian (hessian_ref h, const_argument_ref& x, size_type)
 	const throw ()
       {
 	h.setZero ();
@@ -214,7 +214,7 @@ namespace roboptim
       template <>
       void
       G<EigenMatrixSparse>::impl_hessian
-      (hessian_t& h, const_argument_ref& x, size_type functionId) const throw ()
+      (hessian_ref h, const_argument_ref& x, size_type functionId) const throw ()
       {
 	if (functionId == 0)
 	  {
@@ -247,7 +247,7 @@ namespace roboptim
       template <typename T>
       void
       G<T>::impl_hessian
-      (hessian_t& h, const_argument_ref& x, size_type functionId)
+      (hessian_ref h, const_argument_ref& x, size_type functionId)
 	const throw ()
       {
 	if (functionId == 0)


### PR DESCRIPTION
The two problems weren't using Eigen::Ref on Hessian Matrixes and thus couldn't compile.
